### PR TITLE
[feature/#5/gunicorn_conf] add gunicorn conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ https://medium.com/@elastic7327/python%EA%B0%9C%EB%B0%9C%EC%9E%90-uwsgi%EB%A5%BC
 
 ## 도커 빌드 하는방법 Example
 ```
-docker build -t django_gunicorn:0.0.1
+docker build -t django_gunicorn:0.0.1 .
 ```
 
 ## 빌드한 도커 이미지를 실행하는 방법  Example

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -1,0 +1,23 @@
+import multiprocessing
+
+name = 'django_gunicorn'
+bind = 'unix:/project/django_gunicorn.sock'
+workers = multiprocessing.cpu_count() * 2 + 1
+keepalive = 32
+worker_connections = 1000 * workers
+worker_class = "gevent"
+reload = True
+loglevel = 'info'
+logfile = '-'
+spew = False
+
+max_requests = 1000
+max_requests_jitter = 50
+graceful_timeout = 15
+timeout = 15
+
+BASE_DIR = "/project/django_gunicorn"
+pythonpath = BASE_DIR
+chdir = BASE_DIR
+
+preload_app = False

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,8 @@
 atomicwrites==1.3.0
 attrs==19.1.0
 Django==2.2.8
+gevent==1.4.0
+greenlet==0.4.15
 gunicorn==19.9.0
 importlib-metadata==0.18
 more-itertools==7.0.0

--- a/supervisor-app-staging.conf
+++ b/supervisor-app-staging.conf
@@ -1,14 +1,24 @@
-# supervisor.conf
 [supervisord]
+loglevel = INFO
 nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+
+[unix_http_server]
+file = /project/django_gunicorn.sock
+chmod = 0700
+username = dummy
+password = dummy
 
 [program:gunicorn]
-command=gunicorn --workers %(ENV_WORKER_NO)s --bind unix:/project/django_gunicorn.sock django_gunicorn.wsgi.%(ENV_SERVICE_ENV)s
+command=gunicorn django_gunicorn.wsgi.%(ENV_SERVICE_ENV)s -c /project/gunicorn_conf.py
 directory=/project/django_gunicorn
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/django_gunicorn.err.log
-stdout_logfile=/var/log/django_gunicorn.out.log
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
 
 [program:nginx]
 command = /usr/sbin/nginx
@@ -16,3 +26,8 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+redirect_stderr=true
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+


### PR DESCRIPTION
번거롭게 worker env를 docker env 로 받아올 필요없고, 잘못된 워커수로 인해서 퍼포먼스 이슈가 발생하는것 막아줌 
There is no need to take worker env as docker env and prevent performance issues from occurring due to incorrect number of walkers.